### PR TITLE
Variable repeat ranges

### DIFF
--- a/sml-parser/src/message_stream/mod.rs
+++ b/sml-parser/src/message_stream/mod.rs
@@ -10,11 +10,16 @@ use crate::{
 };
 
 /// Read SML message stream from a reader
+///
 /// ```
 /// use std::io::Cursor;
+/// use hackdose_sml_parser::message_stream::sml_message_stream;
 ///
-/// let cursor = Cursor::new(vec![0x01, 0x02, 0x03]);
-/// let message_stream = sml_message_stream(cursor);
+/// #[tokio::main()]
+/// async fn main() {
+///     let cursor = Cursor::new(vec![0x01, 0x02, 0x03]);
+///     let message_stream = sml_message_stream(cursor);
+/// }
 /// ```
 pub fn sml_message_stream(
     mut stream: impl AsyncRead + Unpin + Send + 'static,


### PR DESCRIPTION
Fixes https://github.com/torfmaster/hackdose-sml-parser/issues/2.

- Use variable repeat ranges in SML parser grammar
- Fix doc example for `sml_message_stream()`
