### PR TITLE
Support Tasmota power switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +83,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
@@ -358,6 +375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-iterator"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +571,7 @@ dependencies = [
 name = "hackdose-server"
 version = "0.9.2"
 dependencies = [
+ "async-trait",
  "byteorder",
  "chrono",
  "clap 4.0.23",
@@ -553,6 +580,7 @@ dependencies = [
  "hackdose-sml-parser",
  "plotters",
  "rand",
+ "reqwest",
  "serde",
  "serde_yaml",
  "tokio",
@@ -588,7 +616,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -753,6 +781,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "itoa"
@@ -1241,12 +1275,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1645,7 +1713,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -1823,6 +1891,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,3 +2028,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,8 @@ serde = { version="1.0.147", features=["serde_derive"] }
 serde_yaml = "0.9.14"
 clap = { version="4.0.23", features=["derive"]}
 tokio-stream = { version="0.1.11", features=["sync"] }
+reqwest = { version="0.11.14", default-features = false }
+async-trait = "0.1.64"
 
 [profile.release]
 lto = true

--- a/server/config-sample.yaml
+++ b/server/config-sample.yaml
@@ -1,5 +1,11 @@
-actors: 
-  - address: 192.168.178.12:9999
+actors:
+  - !Tasmota
+    url: http://192.168.178.94
+    disable_threshold: 100
+    enable_threshold: -100
+    duration_minutes: 60
+  - !HS100
+    address: 192.168.178.12:9999
     disable_threshold: 100
     enable_threshold: -100
     duration_minutes: 60

--- a/server/src/actors/hs100.rs
+++ b/server/src/actors/hs100.rs
@@ -1,0 +1,37 @@
+use tokio::task::spawn_blocking;
+use tplinker::capabilities::Switch;
+use tplinker::devices::HS100;
+
+use super::PowerSwitch;
+
+pub(crate) struct HS100Switch {
+    pub(crate) address: String,
+}
+
+#[async_trait::async_trait]
+impl PowerSwitch for HS100Switch {
+    async fn on(&mut self) {
+        let address = self.address.clone();
+        spawn_blocking(move || {
+            let dev = HS100::new(&address);
+            if let Ok(dev) = dev {
+                let _ = dev.switch_on();
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn off(&mut self) {
+        let address = self.address.clone();
+
+        spawn_blocking(move || {
+            let dev = HS100::new(&address);
+            if let Ok(dev) = dev {
+                let _ = dev.switch_off();
+            }
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/server/src/actors/tasmota.rs
+++ b/server/src/actors/tasmota.rs
@@ -1,0 +1,24 @@
+use reqwest::Url;
+
+use super::PowerSwitch;
+
+pub(crate) struct TasmotaSwitch {
+    pub(crate) url: String,
+}
+
+#[async_trait::async_trait]
+impl PowerSwitch for TasmotaSwitch {
+    async fn on(&mut self) {
+        let mut url = Url::parse(&self.url).unwrap().join("cm").unwrap();
+        url.query_pairs_mut().append_pair("cmnd", "Power on");
+
+        let _ = reqwest::get(url).await;
+    }
+
+    async fn off(&mut self) {
+        let mut url = Url::parse(&self.url).unwrap().join("cm").unwrap();
+        url.query_pairs_mut().append_pair("cmnd", "Power off");
+
+        let _ = reqwest::get(url).await;
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,7 +4,7 @@ use data::EnergyData;
 use hackdose_sml_parser::application::domain::AnyValue;
 use hackdose_sml_parser::application::obis::Obis;
 use hackdose_sml_parser::message_stream::sml_message_stream;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use smart_meter::{enable_ir_sensor_power_supply, uart_ir_sensor_data_stream};
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
@@ -21,15 +21,28 @@ mod data;
 mod rest;
 mod smart_meter;
 
-#[derive(Deserialize, Clone)]
-struct ActorConfiguration {
+#[derive(Serialize, Deserialize, Clone)]
+enum ActorConfiguration {
+    HS100(HS100Configuration),
+    Tasmota(TasmotaConfiguration),
+}
+#[derive(Serialize, Deserialize, Clone)]
+struct HS100Configuration {
     address: String,
     disable_threshold: isize,
     enable_threshold: isize,
     duration_minutes: usize,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
+struct TasmotaConfiguration {
+    url: String,
+    disable_threshold: isize,
+    enable_threshold: isize,
+    duration_minutes: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct Configuration {
     actors: Vec<ActorConfiguration>,
     log_location: PathBuf,


### PR DESCRIPTION
This PR adds support for Power switches with tasmota firmware. 
It introduces a breaking change to `config.yaml` format to distinguish between the supported power switches. 